### PR TITLE
(Fix) Change web3.utils.Sha3 to web3.utils.soliditySha3

### DIFF
--- a/server/routes/accounts.js
+++ b/server/routes/accounts.js
@@ -37,7 +37,11 @@ const signBankAccount = (req, res) => {
       const accessToken = await accountsController.getAccessToken(token)
 
       const bankAccount = await accountsController.getBankAccount(accessToken, accountId)
-      const hash = web3.utils.sha3(ethAccount + Buffer.from(bankAccount.account).toString('hex'))
+      const hash = web3.utils.soliditySha3(
+        ethAccount +
+          Buffer.from(bankAccount.account).toString('hex') +
+          Buffer.from(bankAccount.institution).toString('hex')
+      )
       const { v, r, s } = web3.eth.accounts.sign(hash, PRIVATE_KEY)
       return res.send({ bankAccount, v, r, s })
     } catch (e) {

--- a/server/tests/accounts.route.spec.js
+++ b/server/tests/accounts.route.spec.js
@@ -10,6 +10,7 @@ const mockBankAccount = {
   bankAccount: {
     account: '9900009606',
     account_id: 'vzeNDwK7KQIm4yEog683uElbp9GRLEFXGK98D',
+    institution: 'Bank One',
     routing: '011401533',
     wire_routing: '021000021'
   }
@@ -31,14 +32,16 @@ jest.mock('../controllers/accounts', () => ({
   }),
   getBankAccount: jest.fn((accessToken, accountId) => {
     if (accessToken === mockAccessToken && accountId === mockBankAccounts.numbers.ach[0].account_id)
-      return mockBankAccounts.numbers.ach[0]
+      return mockBankAccount.bankAccount
     throw new Error('There was an error getting the transaction data')
   })
 }))
 jest.mock('web3', () =>
   jest.fn().mockImplementation(() => ({
     utils: {
-      sha3: jest.fn(() => '0xc20eab54de62a1151b630cc74fdfc40cf58e919325e294aa124a6ec3b52f542f')
+      soliditySha3: jest.fn(
+        () => '0xc20eab54de62a1151b630cc74fdfc40cf58e919325e294aa124a6ec3b52f542f'
+      )
     },
     eth: {
       accounts: {


### PR DESCRIPTION
Since we changed and used
```
bytes32 hash = keccak256(
    abi.encodePacked(
      msg.sender,
        ba.accountNumber,
        ba.bankName
    ));
``` 
instead of
```
bytes32 hash = keccak256(msg.sender,
        ba.accountNumber,
        ba.bankName);
```
in the smart-contract, it is necessary to change the method `web3.utils.sha3` to` web3.utils.soliditySha3` in the javascript code when we making the signature.