### PR TITLE
(contract) Store in the contract the "name" value of Plaid's /identity enpoint response

### DIFF
--- a/blockchain/contracts/PoBA.sol
+++ b/blockchain/contracts/PoBA.sol
@@ -111,12 +111,12 @@ contract PoBA {
     emit LogBankAccountRegistered(msg.sender, ba.keccakIdentifier);
   }
 
-  function unregisterBankAccount(string account, string institution)
+  function unregisterBankAccount(string account, string institution, string names)
   public checkUserExists(msg.sender)
   {
     bool found;
     uint256 index;
-    (found, index) = userBankAccountByBankAccount(msg.sender, account, institution);
+    (found, index) = userBankAccountByBankAccount(msg.sender, account, institution, names);
     require(found);
 
     // Store keccakIdentifier for logging purpose
@@ -140,14 +140,15 @@ contract PoBA {
   }
 
   // returns (found/not found, index if found/0 if not found, confirmed/not confirmed)
-  function userBankAccountByBankAccount(address wallet, string account, string institution)
+  function userBankAccountByBankAccount(address wallet, string account, string institution, string names)
   public view checkUserExists(wallet) returns(bool, uint256)
   {
     bytes32 keccakIdentifier = keccak256(
       abi.encodePacked(
         wallet,
         account,
-        institution
+        institution,
+        names
       ));
     return userBankAccountByKeccakIdentifier(wallet, keccakIdentifier);
   }

--- a/blockchain/contracts/PoBA.sol
+++ b/blockchain/contracts/PoBA.sol
@@ -13,6 +13,7 @@ contract PoBA {
   struct BankAccount {
     string accountNumber;
     string bankName;
+    string identityNames;
     uint256 attestationDate;
     bool attestationFact;
     bytes32 keccakIdentifier;
@@ -49,9 +50,9 @@ contract PoBA {
   function signerIsValid(bytes32 data, uint8 v, bytes32 r, bytes32 s)
   public constant returns (bool)
   {
-      bytes memory prefix = "\x19Ethereum Signed Message:\n32";
-      bytes32 prefixed = keccak256(abi.encodePacked(prefix, data));
-      return (ecrecover(prefixed, v, r, s) == signer);
+    bytes memory prefix = "\x19Ethereum Signed Message:\n32";
+    bytes32 prefixed = keccak256(abi.encodePacked(prefix, data));
+    return (ecrecover(prefixed, v, r, s) == signer);
   }
 
   function userExists(address wallet)
@@ -71,6 +72,7 @@ contract PoBA {
   function register(
     string account,
     string institution,
+    string names,
     uint8 v, bytes32 r, bytes32 s) public {
 
     require(bytes(account).length > 0);
@@ -87,6 +89,7 @@ contract PoBA {
 
     ba.accountNumber = account;
     ba.bankName = institution;
+    ba.identityNames = names;
     ba.attestationDate = now;
     ba.attestationFact = true;
     ba.creationBlock = block.number;
@@ -95,7 +98,8 @@ contract PoBA {
       abi.encodePacked(
         msg.sender,
         ba.accountNumber,
-        ba.bankName
+        ba.bankName,
+        ba.identityNames
       )
     );
     require(signerIsValid(hash, v, r, s));
@@ -165,11 +169,12 @@ contract PoBA {
   }
 
   function getBankAccounts(address _address, uint256 addressIndex) public constant
-  returns (string accountNumber, string bankName, uint256 attestationDate)
+  returns (string accountNumber, string bankName, string identityNames, uint256 attestationDate)
   {
     return (
     users[_address].bankAccounts[addressIndex].accountNumber,
     users[_address].bankAccounts[addressIndex].bankName,
+    users[_address].bankAccounts[addressIndex].identityNames,
     users[_address].bankAccounts[addressIndex].attestationDate
     );
   }

--- a/frontend/src/ui/pages/BankAccountsPage.js
+++ b/frontend/src/ui/pages/BankAccountsPage.js
@@ -65,6 +65,7 @@ class BankAccountsPage extends Component {
       const registerResult = await this.pobaContract.register(
         txData.bankAccount.account,
         txData.bankAccount.institution,
+        txData.identityNames,
         txData.v,
         txData.r,
         txData.s,

--- a/server/controllers/accounts.js
+++ b/server/controllers/accounts.js
@@ -42,9 +42,20 @@ const getBankAccount = async (accessToken, accountId) => {
   return bankAccount
 }
 
+const getIdentity = async accessToken => {
+  try {
+    const identityResponse = await plaidClient.getIdentity(accessToken)
+    return identityResponse.identity
+  } catch (error) {
+    logger.error({ status: error.status_code }, 'Error getting identity')
+    throw Error(`[getIdentity] ${error.error_code}: ${error.error_message}`)
+  }
+}
+
 module.exports = {
   getAccessToken,
   getBankAccounts,
   getBankAccount,
-  getInstitutionById
+  getInstitutionById,
+  getIdentity
 }

--- a/server/routes/accounts.js
+++ b/server/routes/accounts.js
@@ -55,13 +55,17 @@ const signBankAccount = (req, res) => {
       const accessToken = await accountsController.getAccessToken(token)
 
       const bankAccount = await accountsController.getBankAccount(accessToken, accountId)
+      const identity = await accountsController.getIdentity(accessToken)
+      const identityNames = identity.names.join(', ')
+
       const hash = web3.utils.soliditySha3(
         ethAccount +
           Buffer.from(bankAccount.account).toString('hex') +
-          Buffer.from(bankAccount.institution).toString('hex')
+          Buffer.from(bankAccount.institution).toString('hex') +
+          Buffer.from(identityNames).toString('hex')
       )
       const { v, r, s } = web3.eth.accounts.sign(hash, PRIVATE_KEY)
-      return res.send({ bankAccount, v, r, s })
+      return res.send({ bankAccount, identityNames, v, r, s })
     } catch (e) {
       logger.error(e.message, 'There was an error getting the transaction data')
       return res.status(400).send({ error: e.message })

--- a/server/tests/accounts.route.spec.js
+++ b/server/tests/accounts.route.spec.js
@@ -15,6 +15,7 @@ const mockBankAccount = {
     wire_routing: '021000021'
   }
 }
+const mockNames = 'John Doe'
 const mockSign = {
   v: '0x1b',
   r: '0x9a4acff8fcc5fc48278482669d3db5a728a226c8f82bce2895208c59ca5637b9',
@@ -37,6 +38,9 @@ jest.mock('../controllers/accounts', () => ({
   }),
   getInstitutionById: jest.fn(() => {
     return { name: 'Chase' }
+  }),
+  getIdentity: jest.fn(() => {
+    return { names: [mockNames] }
   })
 }))
 jest.mock('web3', () =>
@@ -120,7 +124,7 @@ describe('[routes] accounts', () => {
         accountId: mockBankAccounts.numbers.ach[0].account_id
       })
       .then(res => {
-        expect(res.body).toEqual({ ...mockBankAccount, ...mockSign })
+        expect(res.body).toEqual({ ...mockBankAccount, identityNames: mockNames, ...mockSign })
         expect(res.status).toEqual(200)
       }))
 })


### PR DESCRIPTION
### Includes

* Add `identityNames` field to `BankAccount` to the main contract `PoBA.sol` (and the corresponding methods in the contract)
* Update the corresponding contract tests and server tests.

### Waiting for definitions

Plaid's [Identity endpoint](https://plaid.com/docs/#identity) returns the user name(s) using an Array, and it is not clear why (_why not just a single String?_). 

I contacted they support team and opened a case to ask about the reason(s) behind the Array usage for the field. This is what I wrote them:

>I'm writing to ask if there is a specific reason (or multiple reasons) on why the "names" field in the reponse of the /identity endpoint is an Array element.
> Given that, on an application we are developing we may show this information on screen, we are not sure if it is safe to concatenate all the Array's content or just pick it's first item.
