### PR TITLE
[Improvement] Make the UI responsive 

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,7 +37,7 @@ export class AppContainer extends React.Component {
     const { selectedAccount } = this.state
     return (
       <BrowserRouter>
-        <section>
+        <section className="h100percent">
           <Route exact path="/" component={IndexPage} />
           <Route exact path="/help" component={HelpPage} />
           <Route

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -65,11 +65,7 @@ export class AppContainer extends React.Component {
           <Sidebar />
           <Content>
             <Header />
-            <Section>
-              <section className="h100percent">
-                {!web3 || !selectedAccount ? <ErrorPage /> : this.renderRoutes()}
-              </section>
-            </Section>
+            <Section>{!web3 || !selectedAccount ? <ErrorPage /> : this.renderRoutes()}</Section>
             <Footer />
           </Content>
         </Main>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,18 +37,20 @@ export class AppContainer extends React.Component {
     const { selectedAccount } = this.state
     return (
       <BrowserRouter>
-        <Route exact path="/" component={IndexPage} />
-        <Route exact path="/help" component={HelpPage} />
-        <Route
-          path="/bankaccountslist/:token"
-          component={props => (
-            <MyPlaidBankAccountsPage props={props} web3={web3} account={selectedAccount} />
-          )}
-        />
-        <Route
-          path="/mybankaccountslist"
-          component={() => <MyVerifiedBankAccountsPage web3={web3} account={selectedAccount} />}
-        />
+        <section>
+          <Route exact path="/" component={IndexPage} />
+          <Route exact path="/help" component={HelpPage} />
+          <Route
+            path="/bankaccountslist/:token"
+            component={props => (
+              <MyPlaidBankAccountsPage props={props} web3={web3} account={selectedAccount} />
+            )}
+          />
+          <Route
+            path="/mybankaccountslist"
+            component={() => <MyVerifiedBankAccountsPage web3={web3} account={selectedAccount} />}
+          />
+        </section>
       </BrowserRouter>
     )
   }

--- a/frontend/src/ui/containers/BackButton.js
+++ b/frontend/src/ui/containers/BackButton.js
@@ -2,16 +2,17 @@ import React from 'react'
 import glamorous from 'glamorous'
 
 import { Link } from 'react-router-dom'
-import buttonStyle from '../styles/button'
+import { responsiveButtonStyles } from '../styles/button'
 import align from '../styles/align'
 import { backIconStyles } from '../styles/icons'
 
 const BackIcon = glamorous.i(backIconStyles, align.iconRight)
+const ResponsiveButton = glamorous.button(responsiveButtonStyles)
 
 export default () => (
   <Link to="/">
-    <button style={buttonStyle}>
+    <ResponsiveButton>
       Back <BackIcon />
-    </button>
+    </ResponsiveButton>
   </Link>
 )

--- a/frontend/src/ui/containers/PlaidButton.js
+++ b/frontend/src/ui/containers/PlaidButton.js
@@ -9,7 +9,7 @@ import { rightArrowIconStyles } from '../styles/icons'
 const RightArrowIcon = glamorous.i(rightArrowIconStyles, align.iconRight)
 // React-plaid-link wraps its <button> in a div with display:block
 // the wrapper allows us to style accordingly and make it responsive
-const PlaidLinkWrapper = glamorous.span('plaid-link,wrapper', plaidLinkWrapperStyles)
+const PlaidLinkWrapper = glamorous.span('plaid-link-wrapper', plaidLinkWrapperStyles)
 
 class PlaidButton extends Component {
   constructor() {

--- a/frontend/src/ui/containers/PlaidButton.js
+++ b/frontend/src/ui/containers/PlaidButton.js
@@ -3,10 +3,13 @@ import { Redirect } from 'react-router-dom'
 import glamorous from 'glamorous'
 import PlaidLink from 'react-plaid-link'
 import align from '../styles/align'
-import { plaidButtonStyles } from '../styles/button'
+import { plaidButtonStyles, plaidLinkWrapperStyles } from '../styles/button'
 import { rightArrowIconStyles } from '../styles/icons'
 
 const RightArrowIcon = glamorous.i(rightArrowIconStyles, align.iconRight)
+// React-plaid-link wraps its <button> in a div with display:block
+// the wrapper allows us to style accordingly and make it responsive
+const PlaidLinkWrapper = glamorous.span('plaid-link,wrapper', plaidLinkWrapperStyles)
 
 class PlaidButton extends Component {
   constructor() {
@@ -29,7 +32,7 @@ class PlaidButton extends Component {
     return plaidToken ? (
       <Redirect to={bankAccountsListState} />
     ) : (
-      <span className="plaid-link-wrapper">
+      <PlaidLinkWrapper>
         <PlaidLink
           clientName="Proof of Bank Account"
           env={process.env.REACT_APP_PLAID_ENV}
@@ -41,7 +44,7 @@ class PlaidButton extends Component {
         >
           Continue <RightArrowIcon />
         </PlaidLink>
-      </span>
+      </PlaidLinkWrapper>
     )
   }
 }

--- a/frontend/src/ui/containers/__tests__/PlaidButton.js
+++ b/frontend/src/ui/containers/__tests__/PlaidButton.js
@@ -1,7 +1,14 @@
 import React from 'react'
-import { configure, mount, shallow } from 'enzyme'
+import { configure, mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import PlaidButton from '../PlaidButton'
+
+// Mock react-router's Redirect
+jest.mock('react-router-dom', () => {
+  return {
+    Redirect: () => <a href="./redirect">A redirect</a>
+  }
+})
 
 configure({ adapter: new Adapter() })
 
@@ -12,13 +19,13 @@ describe('PlaidButton', () => {
     expect(wrapper.find('PlaidLink')).toHaveLength(1)
   })
   it('renders a Redirect (to bank accouts list) upon state.plaidToken set', done => {
-    const wrapper = shallow(<PlaidButton />)
+    const wrapper = mount(<PlaidButton />)
     expect(wrapper.find('.plaid-link-wrapper')).toHaveLength(1)
     expect(wrapper.find('PlaidLink')).toHaveLength(1)
     wrapper.setState({
       plaidToken: 'something'
     })
-    wrapper.update()
+    console.warn(wrapper.html().toString())
     expect(wrapper.find('Redirect')).toHaveLength(1)
     done()
   })

--- a/frontend/src/ui/layout/Footer.js
+++ b/frontend/src/ui/layout/Footer.js
@@ -4,12 +4,11 @@ import Socials from './Socials'
 import { footerStyles, footerTextStyles } from '../styles/layout'
 
 const FooterWrapper = glamorous.footer('footer', footerStyles)
+const FooterText = glamorous.p('rights-reserved', footerTextStyles)
 
 const Footer = () => (
   <FooterWrapper>
-    <p className="rights-reserved" style={footerTextStyles}>
-      2018 POA Network. All rights reserved.
-    </p>
+    <FooterText>2018 POA Network. All rights reserved.</FooterText>
     <Socials />
   </FooterWrapper>
 )

--- a/frontend/src/ui/layout/Socials.js
+++ b/frontend/src/ui/layout/Socials.js
@@ -15,13 +15,16 @@ const TelegramIcon = glamorous.i(telegramIconStyles)
 const GithubIcon = glamorous.i(githubIconStyles)
 
 const socialAnchorStyles = {
-  marginLeft: '20px',
+  marginLeft: '10px',
+  marginRight: '10px',
   lineHeight: footerHeight,
   height: footerHeight
 }
 
+const SocialContainer = glamorous.p('social-container', socialsStyles)
+
 const Socials = () => (
-  <p className="social-container" style={socialsStyles}>
+  <SocialContainer>
     <a
       className="social-item"
       href="https://twitter.com/poanetwork"
@@ -58,7 +61,7 @@ const Socials = () => (
     >
       <GithubIcon />
     </a>
-  </p>
+  </SocialContainer>
 )
 
 export default Socials

--- a/frontend/src/ui/pages/HelpPage.js
+++ b/frontend/src/ui/pages/HelpPage.js
@@ -1,11 +1,26 @@
 import React from 'react'
-import { H1, P } from 'glamorous'
+import glamorous, { P } from 'glamorous'
 import WithBackButton from './WithBackButton'
+import { breakpoints } from '../styles/constants'
+
+// @TODO: glamour does not support setting media queries globally
+// https://github.com/threepointone/glamor/issues/333
+const ResponsiveH1 = glamorous.h1({
+  [`@media(min-width: ${breakpoints.md})`]: {
+    fontSize: '36px',
+    paddingTop: '100px'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    fontSize: '26px',
+    paddingTop: '30px',
+    lineHeight: '48px'
+  }
+})
 
 const HelpPage = () => {
   return (
     <div className="help-page">
-      <H1>How it works?</H1>
+      <ResponsiveH1>How it works?</ResponsiveH1>
       <P>
         <strong>Step 1: Connect Bank Account</strong>
         <br />

--- a/frontend/src/ui/pages/IndexPage.js
+++ b/frontend/src/ui/pages/IndexPage.js
@@ -1,18 +1,42 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import glamorous, { P, H1, H2 } from 'glamorous'
+import glamorous, { P, H2 } from 'glamorous'
 import PlaidButton from '../containers/PlaidButton'
 import { responsiveButtonStyles } from '../styles/button'
 import align from '../styles/align'
 import { howItWorksIconStyles, myAccountsIconStyles } from '../styles/icons'
+import { breakpoints } from '../styles/constants'
 
 const HowItWorksIcon = glamorous.i(howItWorksIconStyles, align.iconRight)
 const MyAccountsIcon = glamorous.i(myAccountsIconStyles, align.iconRight)
 const ResponsiveButton = glamorous.button(responsiveButtonStyles)
 
+// @TODO: glamour does not support setting media queries globally
+// https://github.com/threepointone/glamor/issues/333
+const ResponsiveH1 = glamorous.h1({
+  [`@media(min-width: ${breakpoints.md})`]: {
+    fontSize: '36px',
+    paddingTop: '100px'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    fontSize: '26px',
+    paddingTop: '30px',
+    lineHeight: '48px'
+  }
+})
+const ResponsiveH2 = glamorous.h2({
+  [`@media(min-width: ${breakpoints.md})`]: {
+    marginTop: '70px'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    fontSize: '20px',
+    marginTop: '40px'
+  }
+})
+
 const IndexPage = () => (
   <div>
-    <H1>Proof of bank account</H1>
+    <ResponsiveH1>Proof of bank account</ResponsiveH1>
     <P className="main">
       This ĐApp can be used to prove your ownership of a bank account in one of the supported banks.
       A widget provided by <a href="https://plaid.com/">Plaid</a> is used to verify that you have
@@ -27,7 +51,7 @@ const IndexPage = () => (
     </Link>
     <PlaidButton />
 
-    <H2>My bank accounts</H2>
+    <ResponsiveH2>My bank accounts</ResponsiveH2>
     <P>To view the list of your verified bank accounts click the button below.</P>
     <Link to="/mybankaccountslist">
       <ResponsiveButton>

--- a/frontend/src/ui/pages/IndexPage.js
+++ b/frontend/src/ui/pages/IndexPage.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import glamorous, { P, H2 } from 'glamorous'
+import glamorous, { P } from 'glamorous'
 import PlaidButton from '../containers/PlaidButton'
 import { responsiveButtonStyles } from '../styles/button'
 import align from '../styles/align'

--- a/frontend/src/ui/pages/IndexPage.js
+++ b/frontend/src/ui/pages/IndexPage.js
@@ -2,12 +2,13 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import glamorous, { P, H1, H2 } from 'glamorous'
 import PlaidButton from '../containers/PlaidButton'
-import buttonStyle from '../styles/button'
+import { responsiveButtonStyles } from '../styles/button'
 import align from '../styles/align'
 import { howItWorksIconStyles, myAccountsIconStyles } from '../styles/icons'
 
 const HowItWorksIcon = glamorous.i(howItWorksIconStyles, align.iconRight)
 const MyAccountsIcon = glamorous.i(myAccountsIconStyles, align.iconRight)
+const ResponsiveButton = glamorous.button(responsiveButtonStyles)
 
 const IndexPage = () => (
   <div>
@@ -20,18 +21,18 @@ const IndexPage = () => (
       <strong>How it works</strong> section.
     </P>
     <Link to="/help">
-      <button style={buttonStyle}>
+      <ResponsiveButton>
         How it works <HowItWorksIcon />
-      </button>
+      </ResponsiveButton>
     </Link>
     <PlaidButton />
 
     <H2>My bank accounts</H2>
     <P>To view the list of your verified bank accounts click the button below.</P>
     <Link to="/mybankaccountslist">
-      <button style={buttonStyle}>
+      <ResponsiveButton>
         My Bank Accounts <MyAccountsIcon />
-      </button>
+      </ResponsiveButton>
     </Link>
   </div>
 )

--- a/frontend/src/ui/pages/__tests__/WithBackButton.js
+++ b/frontend/src/ui/pages/__tests__/WithBackButton.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { configure, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import WithBackButton from '../WithBackButton'
+import BackButton from '../../containers/BackButton'
 
 configure({ adapter: new Adapter() })
 
@@ -23,7 +24,7 @@ describe('WithBackButton high order component', () => {
     expect(WrappedContentShallow.find('.with-back-button-wrapped-content')).toHaveLength(1)
 
     // Check that the back button is rendered too (at a specific position)
-    const BackButtonShallow = WithBackButtonShallow.childAt(1).shallow()
-    expect(BackButtonShallow.find('button')).toHaveLength(1)
+    const BackButtonShallow = WithBackButtonShallow.childAt(1)
+    expect(BackButtonShallow.find(BackButton)).toHaveLength(1)
   })
 })

--- a/frontend/src/ui/presentational/Loading.js
+++ b/frontend/src/ui/presentational/Loading.js
@@ -17,6 +17,8 @@ const fadeOut = css.keyframes({
 })
 
 const LoadingContainer = glamorous.div('loading-container', {
+  display: 'flex',
+  justifyContent: 'center',
   position: 'fixed',
   zIndex: 1000000,
   left: 0,
@@ -29,13 +31,12 @@ const LoadingContainer = glamorous.div('loading-container', {
 const LoadingInner = glamorous.div('loading-inner', {
   display: 'flex',
   justifyContent: 'space-between',
-  position: 'absolute',
-  left: '50%',
-  top: '50%',
   width: '234px',
-  margin: '-30px 0 0 -81.5px',
+  flexGrow: 0,
+  flexShrink: 0,
+  alignSelf: 'center',
+  position: 'relative',
   paddingTop: '50px',
-
   '&:before': {
     content: "''",
     position: 'absolute',

--- a/frontend/src/ui/styles/bankAccountItemListStyles.js
+++ b/frontend/src/ui/styles/bankAccountItemListStyles.js
@@ -1,34 +1,81 @@
 import colors from './colors'
+import { breakpoints } from './constants'
 import { accountItemListButtonStyles } from './button'
 
 export const bankAccountListStyles = {
   paddingTop: '20px'
 }
 
+const baseAccountItemListVerticalGridStyles = {
+  height: '100%',
+  gridGap: '14px',
+  gridTemplateColumns: 'auto',
+  padding: '14px'
+}
+const baseAccountItemListHorizontalGridStyles = {
+  gridGap: 0,
+  height: '80px'
+}
+
 const baseAccountItemListStyles = {
   display: 'grid',
   border: `1px solid ${colors.accountItemListBorder}`,
   borderRadius: '5px',
-  gridTemplateColumns: '80px auto 100px 120px',
-  gridTemplateAreas: `'icon info remove date'`,
-  gridGap: 0,
   marginBottom: '1.5em',
-  width: '560px',
-  height: '80px',
   cursor: 'pointer',
   ':hover': {
     boxShadow: `0px 10px 30px 0 rgba(76, 43, 134, 0.2)`
+  },
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    ...baseAccountItemListVerticalGridStyles,
+    gridTemplateAreas: `
+      'icon'
+      'info'
+      'date'
+      'remove'`
+  },
+  [`@media(min-width: ${breakpoints.xs})`]: {
+    ...baseAccountItemListHorizontalGridStyles,
+    gridTemplateColumns: '80px auto 100px 120px',
+    gridTemplateAreas: `'icon info remove date'`
+  },
+  [`@media(min-width: ${breakpoints.md})`]: {
+    width: '560px'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    width: '100%'
   }
 }
 export const bankAccountItemListStyles = {
   ...baseAccountItemListStyles,
-  gridTemplateColumns: '80px auto 100px 120px',
-  gridTemplateAreas: `'icon info remove date'`
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    ...baseAccountItemListVerticalGridStyles,
+    gridTemplateAreas: `
+      'icon'
+      'info'
+      'remove'
+      'date'`
+  },
+  [`@media(min-width: ${breakpoints.xs})`]: {
+    ...baseAccountItemListHorizontalGridStyles,
+    gridTemplateColumns: '80px auto 100px 120px',
+    gridTemplateAreas: `'icon info remove date'`
+  }
 }
 export const unverifiedBankAccountItemListStyles = {
   ...baseAccountItemListStyles,
-  gridTemplateColumns: '80px auto 130px',
-  gridTemplateAreas: `'icon info  verify'`
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    ...baseAccountItemListVerticalGridStyles,
+    gridTemplateAreas: `
+      'icon'
+      'info'
+      'verify'`
+  },
+  [`@media(min-width: ${breakpoints.xs})`]: {
+    ...baseAccountItemListHorizontalGridStyles,
+    gridTemplateColumns: '80px auto 130px',
+    gridTemplateAreas: `'icon info verify'`
+  }
 }
 
 export const infoWrapperStyles = {
@@ -39,10 +86,15 @@ export const infoWrapperStyles = {
 }
 export const infoParagraphStyles = {
   width: '100%',
-  textAlign: 'left',
   height: 'auto',
   alignSelf: 'center',
-  lineHeight: '1.5em'
+  lineHeight: '1.5em',
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    textAlign: 'center'
+  },
+  [`@media(min-width: ${breakpoints.xs})`]: {
+    textAlign: 'left'
+  }
 }
 
 export const dateWrapperStyles = {
@@ -54,20 +106,35 @@ export const dateWrapperStyles = {
 export const dateParagraphStyles = {
   color: colors.accountItemDateTextColor,
   height: 'auto',
-  padding: '0 20px 0 0',
   width: '100%',
-  textAlign: 'right',
-  placeSelf: 'center'
+  placeSelf: 'center',
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    padding: '0',
+    textAlign: 'center'
+  },
+  [`@media(min-width: ${breakpoints.xs})`]: {
+    padding: '0 20px 0 0',
+    textAlign: 'right'
+  }
 }
 
 export const verifyButtonStyles = {
   ...accountItemListButtonStyles,
-  gridArea: 'verify'
+  gridArea: 'verify',
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    height: '34px',
+    justifySelf: 'center',
+    margin: '0'
+  }
 }
 export const removeButtonStyles = {
   ...accountItemListButtonStyles,
   gridArea: 'remove',
-  width: '73px'
+  width: '73px',
+  [`@media(max-width: ${breakpoints.xs})`]: {
+    justifySelf: 'center',
+    margin: '0'
+  }
 }
 
 export const verifiedMessageStyles = {

--- a/frontend/src/ui/styles/button.js
+++ b/frontend/src/ui/styles/button.js
@@ -21,7 +21,7 @@ const buttonStyles = {
   textAlign: 'left',
   textTransform: 'none',
   ':hover': {
-    backgroundColor: '#34c3f8'
+    boxShadow: 'inset 0 0 0 1px #5c34a2'
   },
   ':focus': {
     outline: 'unset'

--- a/frontend/src/ui/styles/button.js
+++ b/frontend/src/ui/styles/button.js
@@ -1,7 +1,7 @@
+import { breakpoints } from './constants'
 import colors from './colors'
 
 const buttonStyles = {
-  width: '200px',
   height: '44px',
   padding: '0 15px',
   marginRight: '20px',
@@ -20,7 +20,6 @@ const buttonStyles = {
   letterSpacing: 'normal',
   textAlign: 'left',
   textTransform: 'none',
-  // float: 'left',
   ':hover': {
     backgroundColor: '#34c3f8'
   },
@@ -29,12 +28,31 @@ const buttonStyles = {
   }
 }
 
+export const responsiveButtonStyles = {
+  ...buttonStyles,
+  [`@media(max-width: ${breakpoints.md})`]: {
+    width: '100%',
+    marginBottom: '16px'
+  },
+  [`@media(min-width: ${breakpoints.md})`]: {
+    width: '200px'
+  }
+}
+
 export const plaidButtonStyles = {
   ...buttonStyles,
   backgroundColor: colors.primary,
   boxShadow: '0px 5px 10px 0 rgba(92, 52, 162, 0.3)',
   border: `solid 1px ${colors.primary}`,
-  color: '#ffffff'
+  color: '#ffffff',
+  width: '100%'
+}
+
+export const plaidLinkWrapperStyles = {
+  [`@media(min-width: ${breakpoints.md})`]: {
+    display: 'inline-block',
+    width: '200px'
+  }
 }
 
 export const accountItemListButtonStyles = {

--- a/frontend/src/ui/styles/constants.js
+++ b/frontend/src/ui/styles/constants.js
@@ -4,7 +4,7 @@ export const logoImage = 'url("/images/logo.png")'
 export const breakpoints = {
   xs: '480px',
   sm: '576px',
-  md: '768px',
+  md: '770px',
   lg: '992px',
   xl: '1200px'
 }

--- a/frontend/src/ui/styles/constants.js
+++ b/frontend/src/ui/styles/constants.js
@@ -5,6 +5,5 @@ export const breakpoints = {
   xs: '480px',
   sm: '576px',
   md: '770px',
-  lg: '992px',
-  xl: '1200px'
+  lg: '992px'
 }

--- a/frontend/src/ui/styles/constants.js
+++ b/frontend/src/ui/styles/constants.js
@@ -1,3 +1,9 @@
 export const headerHeight = '82px'
 export const footerHeight = '50px'
 export const logoImage = 'url("/images/logo.png")'
+export const breakpoints = {
+  sm: '576px',
+  md: '768px',
+  lg: '992px',
+  xl: '1200px'
+}

--- a/frontend/src/ui/styles/constants.js
+++ b/frontend/src/ui/styles/constants.js
@@ -2,6 +2,7 @@ export const headerHeight = '82px'
 export const footerHeight = '50px'
 export const logoImage = 'url("/images/logo.png")'
 export const breakpoints = {
+  xs: '480px',
   sm: '576px',
   md: '768px',
   lg: '992px',

--- a/frontend/src/ui/styles/global.js
+++ b/frontend/src/ui/styles/global.js
@@ -1,10 +1,5 @@
 import { css } from 'glamor'
 
-// react-plaid-link wraps its <button> in a div with display:block
-css.global('.plaid-link-wrapper > div', {
-  display: 'inline-block'
-})
-
 css.global('*', {
   boxSizing: 'border-box'
 })

--- a/frontend/src/ui/styles/layout.js
+++ b/frontend/src/ui/styles/layout.js
@@ -1,4 +1,4 @@
-import { headerHeight, footerHeight } from './constants'
+import { headerHeight, footerHeight, breakpoints } from './constants'
 
 // "main" wraps "sidebar" & "content" in the markup
 export const mainStyles = {
@@ -12,20 +12,33 @@ export const mainStyles = {
 
 export const sidebarStyles = {
   backgroundImage: 'url("/images/pic@3x.jpg")',
-  width: '40%',
-  backgroundSize: 'cover'
+  backgroundSize: 'cover',
+  [`@media(min-width: ${breakpoints.md})`]: {
+    width: '40%'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    width: '0'
+  }
 }
 
 // "content" wraps "header", "section" & "footer" in the markup
 export const contentStyles = {
   display: 'grid',
-  gridTemplateRows: `${headerHeight} 1fr ${footerHeight}`,
   gridTemplateColumns: '1fr',
   height: '100vh',
-  width: '60%',
-  paddingLeft: '50px',
-  paddingRight: '50px',
-  overflow: 'auto'
+  overflow: 'auto',
+  [`@media(min-width: ${breakpoints.md})`]: {
+    gridTemplateRows: `${headerHeight} 1fr ${footerHeight}`,
+    paddingLeft: '50px',
+    paddingRight: '50px',
+    width: '60%'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    gridTemplateRows: `${headerHeight} 1fr 124px`,
+    paddingLeft: '15px',
+    paddingRight: '15px',
+    width: '100%'
+  }
 }
 
 export const headerStyles = {
@@ -42,7 +55,9 @@ export const sectionStyles = {
   gridRowEnd: '2',
   justifySelf: 'start',
   width: '100%',
-  maxWidth: '600px'
+  [`@media(min-width: ${breakpoints.md})`]: {
+    maxWidth: '600px'
+  }
 }
 
 // "footer" wraps "footerText" and "socials" in markup
@@ -50,26 +65,43 @@ export const footerStyles = {
   gridRowStart: '3',
   gridRowEnd: '3',
   alignSelf: 'end',
+  height: '100%',
   width: '100%',
-  maxWidth: '600px',
-  marginTop: '80px',
-  display: 'flex'
+  display: 'flex',
+  [`@media(max-width: ${breakpoints.md})`]: {
+    padding: '40px 0 20px 0',
+    flexDirection: 'column'
+  },
+  [`@media(min-width: ${breakpoints.md})`]: {
+    maxWidth: '600px'
+  }
 }
 
 export const footerTextStyles = {
   color: '#5c34a2',
-  lineHeight: footerHeight,
   marginBottom: 0,
-  textAlign: 'left',
   fontSize: '12px',
   margin: 0,
   flexGrow: 1,
-  flexShrink: 0
+  flexShrink: 0,
+  [`@media(min-width: ${breakpoints.md})`]: {
+    lineHeight: footerHeight,
+    textAlign: 'left'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    lineHeight: '24px',
+    textAlign: 'center'
+  }
 }
 
 export const socialsStyles = {
   flexGrow: 1,
   flexShrink: 0,
   marginBottom: 0,
-  textAlign: 'right'
+  [`@media(min-width: ${breakpoints.md})`]: {
+    textAlign: 'right'
+  },
+  [`@media(max-width: ${breakpoints.md})`]: {
+    textAlign: 'center'
+  }
 }

--- a/frontend/src/ui/styles/layout.js
+++ b/frontend/src/ui/styles/layout.js
@@ -13,11 +13,14 @@ export const mainStyles = {
 export const sidebarStyles = {
   backgroundImage: 'url("/images/pic@3x.jpg")',
   backgroundSize: 'cover',
-  [`@media(min-width: ${breakpoints.md})`]: {
-    width: '40%'
-  },
   [`@media(max-width: ${breakpoints.md})`]: {
     width: '0'
+  },
+  [`@media(min-width: ${breakpoints.md})`]: {
+    width: '30%'
+  },
+  [`@media(min-width: ${breakpoints.lg})`]: {
+    width: '40%'
   }
 }
 
@@ -27,17 +30,21 @@ export const contentStyles = {
   gridTemplateColumns: '1fr',
   height: '100vh',
   overflow: 'auto',
-  [`@media(min-width: ${breakpoints.md})`]: {
-    gridTemplateRows: `${headerHeight} 1fr ${footerHeight}`,
-    paddingLeft: '50px',
-    paddingRight: '50px',
-    width: '60%'
-  },
   [`@media(max-width: ${breakpoints.md})`]: {
     gridTemplateRows: `${headerHeight} 1fr 124px`,
     paddingLeft: '15px',
     paddingRight: '15px',
     width: '100%'
+  },
+  [`@media(min-width: ${breakpoints.md})`]: {
+    gridTemplateRows: `${headerHeight} 1fr ${footerHeight}`,
+    paddingLeft: '50px',
+    paddingRight: '50px',
+    width: '70%'
+  },
+  [`@media(min-width: ${breakpoints.lg})`]: {
+    gridTemplateRows: `${headerHeight} 1fr ${footerHeight}`,
+    width: '60%'
   }
 }
 

--- a/frontend/src/ui/styles/layout.js
+++ b/frontend/src/ui/styles/layout.js
@@ -53,6 +53,7 @@ export const headerStyles = {
 export const sectionStyles = {
   gridRowStart: '2',
   gridRowEnd: '2',
+  height: '100%',
   justifySelf: 'start',
   width: '100%',
   [`@media(min-width: ${breakpoints.md})`]: {


### PR DESCRIPTION
Closes #74 

Make the general UI layout responsive. Use similar breakpoints (from Bootstrap) as the ones used in PoPA's UI.

Short demo:

![poba_make_ui_responsive](https://user-images.githubusercontent.com/4421917/48635447-ede74600-e9a6-11e8-9bbe-7d95c81c0559.gif)
