### PR TITLE
(Improvement) Remove Plaid token from URL

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Route } from 'react-router-dom'
 import { withWeb3 } from 'react-web3-provider'
+import { PlaidContextProvider, PlaidContextManager } from './ui/context/PlaidContext'
 import Header from './ui/layout/Header'
 import Footer from './ui/layout/Footer'
 import Main from './ui/layout/Main'
@@ -17,7 +18,8 @@ export class AppContainer extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      selectedAccount: null
+      selectedAccount: null,
+      plaidContextManager: new PlaidContextManager()
     }
   }
 
@@ -34,24 +36,26 @@ export class AppContainer extends React.Component {
 
   renderRoutes() {
     const { web3 } = this.props
-    const { selectedAccount } = this.state
+    const { selectedAccount, plaidContextManager } = this.state
     return (
-      <BrowserRouter>
-        <section className="h100percent">
-          <Route exact path="/" component={IndexPage} />
-          <Route exact path="/help" component={HelpPage} />
-          <Route
-            path="/bankaccountslist/:token"
-            component={props => (
-              <MyPlaidBankAccountsPage props={props} web3={web3} account={selectedAccount} />
-            )}
-          />
-          <Route
-            path="/mybankaccountslist"
-            component={() => <MyVerifiedBankAccountsPage web3={web3} account={selectedAccount} />}
-          />
-        </section>
-      </BrowserRouter>
+      <PlaidContextProvider value={plaidContextManager}>
+        <BrowserRouter>
+          <section className="h100percent">
+            <Route exact path="/" component={IndexPage} />
+            <Route exact path="/help" component={HelpPage} />
+            <Route
+              path="/bankaccountslist"
+              component={props => (
+                <MyPlaidBankAccountsPage props={props} web3={web3} account={selectedAccount} />
+              )}
+            />
+            <Route
+              path="/mybankaccountslist"
+              component={() => <MyVerifiedBankAccountsPage web3={web3} account={selectedAccount} />}
+            />
+          </section>
+        </BrowserRouter>
+      </PlaidContextProvider>
     )
   }
 

--- a/frontend/src/ui/containers/PlaidButton.js
+++ b/frontend/src/ui/containers/PlaidButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Redirect } from 'react-router-dom'
 import glamorous from 'glamorous'
 import PlaidLink from 'react-plaid-link'
+import { PlaidContextConsumer } from '../context/PlaidContext'
 import align from '../styles/align'
 import { plaidButtonStyles, plaidLinkWrapperStyles } from '../styles/button'
 import { rightArrowIconStyles } from '../styles/icons'
@@ -11,22 +12,21 @@ const RightArrowIcon = glamorous.i(rightArrowIconStyles, align.iconRight)
 // the wrapper allows us to style accordingly and make it responsive
 const PlaidLinkWrapper = glamorous.span('plaid-link-wrapper', plaidLinkWrapperStyles)
 
-class PlaidButton extends Component {
+export class PlaidButton extends Component {
   constructor() {
     super()
     this.state = { plaidToken: null }
-    this.redirectToBankAccountsPage = this.redirectToBankAccountsPage.bind(this)
+    this.setPlaidToken = this.setPlaidToken.bind(this)
   }
 
-  redirectToBankAccountsPage(token) {
-    this.setState({ plaidToken: token })
+  setPlaidToken(plaidToken) {
+    this.props.onPlaidLinkSuccess(plaidToken)
+    this.setState({ plaidToken })
   }
 
   render() {
     const { plaidToken } = this.state
-    const bankAccountsListState = {
-      pathname: '/bankaccountslist/' + plaidToken
-    }
+    const bankAccountsListState = { pathname: '/bankaccountslist' }
 
     // Redirect to list of bank accounts after successful plaid token fetch
     return plaidToken ? (
@@ -39,7 +39,7 @@ class PlaidButton extends Component {
           institution={null}
           publicKey={process.env.REACT_APP_PLAID_PUBLIC_KEY}
           product={['auth']}
-          onSuccess={this.redirectToBankAccountsPage}
+          onSuccess={this.setPlaidToken}
           style={plaidButtonStyles}
         >
           Continue <RightArrowIcon />
@@ -49,4 +49,16 @@ class PlaidButton extends Component {
   }
 }
 
-export default PlaidButton
+export const PlaidContextButton = () => {
+  return (
+    <PlaidContextConsumer>
+      {context => {
+        const setPlaidContextToken = plaidToken => context.setPlaidToken(plaidToken)
+        return <PlaidButton onPlaidLinkSuccess={setPlaidContextToken} />
+      }}
+    </PlaidContextConsumer>
+  )
+}
+
+// Export by default the component wrapped with PlaidContextConsumer
+export default PlaidContextButton

--- a/frontend/src/ui/containers/__tests__/PlaidButton.js
+++ b/frontend/src/ui/containers/__tests__/PlaidButton.js
@@ -1,16 +1,20 @@
 import React from 'react'
 import { configure, mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import PlaidButton from '../PlaidButton'
+import { PlaidButton } from '../PlaidButton'
+
+configure({ adapter: new Adapter() })
 
 // Mock react-router's Redirect
 jest.mock('react-router-dom', () => {
   return {
-    Redirect: () => <a href="./redirect">A redirect</a>
+    Redirect: () => (
+      <a className="redirect" href="./redirect">
+        A redirect
+      </a>
+    )
   }
 })
-
-configure({ adapter: new Adapter() })
 
 describe('PlaidButton', () => {
   it('renders correctly', () => {
@@ -19,13 +23,14 @@ describe('PlaidButton', () => {
     expect(wrapper.find('PlaidLink')).toHaveLength(1)
   })
   it('renders a Redirect (to bank accouts list) upon state.plaidToken set', done => {
-    const wrapper = mount(<PlaidButton />)
+    const callback = jest.fn()
+    const wrapper = mount(<PlaidButton onPlaidLinkSuccess={callback} />)
     expect(wrapper.find('.plaid-link-wrapper')).toHaveLength(1)
     expect(wrapper.find('PlaidLink')).toHaveLength(1)
-    wrapper.setState({
-      plaidToken: 'something'
-    })
-    expect(wrapper.find('Redirect')).toHaveLength(1)
+
+    wrapper.instance().setPlaidToken('PLAIDTOKEN')
+    wrapper.update()
+    expect(wrapper.find('.redirect')).toHaveLength(1)
     done()
   })
 })

--- a/frontend/src/ui/context/PlaidContext.js
+++ b/frontend/src/ui/context/PlaidContext.js
@@ -5,13 +5,15 @@ const PlaidContext = createContext({})
 export const PlaidContextProvider = PlaidContext.Provider
 export const PlaidContextConsumer = PlaidContext.Consumer
 
+const LOCAL_STORAGE_KEY = 'PlaidToken'
+
 export class PlaidContextManager {
   constructor() {
     this.plaidToken = null
     this.setPlaidToken = token => {
-      this.plaidToken = token
+      localStorage.setItem(LOCAL_STORAGE_KEY, token)
     }
-    this.getPlaidToken = () => this.plaidToken
+    this.getPlaidToken = () => localStorage.getItem(LOCAL_STORAGE_KEY)
   }
 }
 

--- a/frontend/src/ui/context/PlaidContext.js
+++ b/frontend/src/ui/context/PlaidContext.js
@@ -1,0 +1,18 @@
+import { createContext } from 'react'
+
+const PlaidContext = createContext({})
+
+export const PlaidContextProvider = PlaidContext.Provider
+export const PlaidContextConsumer = PlaidContext.Consumer
+
+export class PlaidContextManager {
+  constructor() {
+    this.plaidToken = null
+    this.setPlaidToken = token => {
+      this.plaidToken = token
+    }
+    this.getPlaidToken = () => this.plaidToken
+  }
+}
+
+export default PlaidContext

--- a/frontend/src/ui/pages/IndexPage.js
+++ b/frontend/src/ui/pages/IndexPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import glamorous, { P } from 'glamorous'
-import PlaidButton from '../containers/PlaidButton'
+import { PlaidContextButton } from '../containers/PlaidButton'
 import { responsiveButtonStyles } from '../styles/button'
 import align from '../styles/align'
 import { howItWorksIconStyles, myAccountsIconStyles } from '../styles/icons'
@@ -49,7 +49,7 @@ const IndexPage = () => (
         How it works <HowItWorksIcon />
       </ResponsiveButton>
     </Link>
-    <PlaidButton />
+    <PlaidContextButton />
 
     <ResponsiveH2>My bank accounts</ResponsiveH2>
     <P>To view the list of your verified bank accounts click the button below.</P>

--- a/frontend/src/ui/pages/MyPlaidBankAccountsPage.js
+++ b/frontend/src/ui/pages/MyPlaidBankAccountsPage.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import WithBackButton from './WithBackButton'
+import { PlaidContextConsumer } from '../context/PlaidContext'
 import PlaidBankAccounts from '../containers/PlaidBankAccounts'
 import getInstance from '../../PoBAContract'
 import { getBankAccounts, getSignedBankAccount } from '../../PoBAServer'
@@ -8,21 +9,34 @@ function generateGetPoBAContract(web3) {
   return async () => getInstance(web3.currentProvider)
 }
 
-export const MyPlaidAccountsContainer = props => {
-  const plaidToken = props.props.match.params.token
+export const MyPlaidAccountsContainer = ({ account, web3, plaidToken }) => {
   const PoBAServer = {
     getBankAccounts,
     getSignedBankAccount
   }
   const plaidBankAccountsProps = {
-    account: props.account,
-    getPoBAContract: generateGetPoBAContract(props.web3),
+    getPoBAContract: generateGetPoBAContract(web3),
+    account,
     PoBAServer,
     plaidToken
   }
   return <PlaidBankAccounts {...plaidBankAccountsProps} />
 }
 
-const MyPlaidAccountsPage = WithBackButton(MyPlaidAccountsContainer)
+export const MyPlaidContextAccountsContainer = props => {
+  return (
+    <PlaidContextConsumer>
+      {plaidContext => {
+        const propsWithPlaidToken = {
+          ...props,
+          plaidToken: plaidContext.getPlaidToken()
+        }
+        return <MyPlaidAccountsContainer {...propsWithPlaidToken} />
+      }}
+    </PlaidContextConsumer>
+  )
+}
+
+const MyPlaidAccountsPage = WithBackButton(MyPlaidContextAccountsContainer)
 
 export default MyPlaidAccountsPage

--- a/frontend/src/ui/pages/__tests__/MyPlaidBankAccountsPage.js
+++ b/frontend/src/ui/pages/__tests__/MyPlaidBankAccountsPage.js
@@ -5,18 +5,14 @@ import { MyPlaidAccountsContainer } from '../MyPlaidBankAccountsPage'
 
 configure({ adapter: new Adapter() })
 
+jest.mock('../../context/PlaidContext', () => {
+  return {
+    PlaidContextConsumer: args => console.error(args)
+  }
+})
 describe('MyPlaidAccountsContainer', () => {
   it('shallow renders correctly (renders the wrapped PlaidBankAccounts)', () => {
-    const mockedProps = {
-      props: {
-        match: {
-          params: {
-            token: 'FAKEPLAIDTOKEN'
-          }
-        }
-      }
-    }
-    const wrapper = shallow(<MyPlaidAccountsContainer {...mockedProps} />)
+    const wrapper = shallow(<MyPlaidAccountsContainer />)
     expect(wrapper.find('PlaidBankAccounts')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Closes #82 .

* Remove Plaid's token from URL after the authentication step (Plaid's plugin): this prevent unintended Plaid info access for an accidental URL share.
* Store the token in `localStorage` to make the Plaid's bank accounts page more user friendly after a browser refresh.