### PR TITLE
(Improvement) Save Plaid token in localStorage.

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,10 +41,8 @@ export class AppContainer extends React.Component {
           <Route exact path="/" component={IndexPage} />
           <Route exact path="/help" component={HelpPage} />
           <Route
-            path="/bankaccountslist/:token"
-            component={props => (
-              <MyPlaidBankAccountsPage props={props} web3={web3} account={selectedAccount} />
-            )}
+            path="/bankaccountslist"
+            component={() => <MyPlaidBankAccountsPage web3={web3} account={selectedAccount} />}
           />
           <Route
             path="/mybankaccountslist"

--- a/frontend/src/ui/containers/PlaidButton.js
+++ b/frontend/src/ui/containers/PlaidButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Redirect } from 'react-router-dom'
 import glamorous from 'glamorous'
 import PlaidLink from 'react-plaid-link'
+import { setPlaidToken } from '../context/PlaidAuthData'
 import align from '../styles/align'
 import { plaidButtonStyles, plaidLinkWrapperStyles } from '../styles/button'
 import { rightArrowIconStyles } from '../styles/icons'
@@ -15,18 +16,17 @@ class PlaidButton extends Component {
   constructor() {
     super()
     this.state = { plaidToken: null }
-    this.redirectToBankAccountsPage = this.redirectToBankAccountsPage.bind(this)
+    this.setPlaidToken = this.setPlaidToken.bind(this)
   }
 
-  redirectToBankAccountsPage(token) {
-    this.setState({ plaidToken: token })
+  setPlaidToken(plaidToken) {
+    setPlaidToken(plaidToken)
+    this.setState({ plaidToken })
   }
 
   render() {
     const { plaidToken } = this.state
-    const bankAccountsListState = {
-      pathname: '/bankaccountslist/' + plaidToken
-    }
+    const bankAccountsListState = { pathname: '/bankaccountslist' }
 
     // Redirect to list of bank accounts after successful plaid token fetch
     return plaidToken ? (
@@ -39,7 +39,7 @@ class PlaidButton extends Component {
           institution={null}
           publicKey={process.env.REACT_APP_PLAID_PUBLIC_KEY}
           product={['auth']}
-          onSuccess={this.redirectToBankAccountsPage}
+          onSuccess={this.setPlaidToken}
           style={plaidButtonStyles}
         >
           Continue <RightArrowIcon />

--- a/frontend/src/ui/containers/__tests__/PlaidButton.js
+++ b/frontend/src/ui/containers/__tests__/PlaidButton.js
@@ -10,6 +10,18 @@ jest.mock('react-router-dom', () => {
   }
 })
 
+// Fake localStorage
+const localStorage = {
+  setItem(key, value) {
+    this.keyValues = {}
+    this.keyValues[key] = value
+  },
+  getItem(key) {
+    return this.keyValues[key]
+  }
+}
+window.localStorage = localStorage
+
 configure({ adapter: new Adapter() })
 
 describe('PlaidButton', () => {

--- a/frontend/src/ui/context/PlaidAuthData.js
+++ b/frontend/src/ui/context/PlaidAuthData.js
@@ -1,0 +1,5 @@
+const LOCAL_STORAGE_KEY = 'PlaidToken'
+
+// Simple methods to interface with localStorage, and to keep this out of UI components
+export const getPlaidToken = () => localStorage.getItem(LOCAL_STORAGE_KEY)
+export const setPlaidToken = token => localStorage.setItem(LOCAL_STORAGE_KEY, token)

--- a/frontend/src/ui/pages/MyPlaidBankAccountsPage.js
+++ b/frontend/src/ui/pages/MyPlaidBankAccountsPage.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { getPlaidToken } from '../context/PlaidAuthData'
 import WithBackButton from './WithBackButton'
 import PlaidBankAccounts from '../containers/PlaidBankAccounts'
 import getInstance from '../../PoBAContract'
@@ -9,7 +10,7 @@ function generateGetPoBAContract(web3) {
 }
 
 export const MyPlaidAccountsContainer = props => {
-  const plaidToken = props.props.match.params.token
+  const plaidToken = getPlaidToken()
   const PoBAServer = {
     getBankAccounts,
     getSignedBankAccount

--- a/frontend/src/ui/pages/__tests__/MyPlaidBankAccountsPage.js
+++ b/frontend/src/ui/pages/__tests__/MyPlaidBankAccountsPage.js
@@ -2,21 +2,26 @@ import React from 'react'
 import { configure, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { MyPlaidAccountsContainer } from '../MyPlaidBankAccountsPage'
+import { setPlaidToken } from '../../context/PlaidAuthData'
 
 configure({ adapter: new Adapter() })
 
+// Fake localStorage
+const localStorage = {
+  setItem(key, value) {
+    this.keyValues = {}
+    this.keyValues[key] = value
+  },
+  getItem(key) {
+    return this.keyValues[key]
+  }
+}
+window.localStorage = localStorage
+
 describe('MyPlaidAccountsContainer', () => {
   it('shallow renders correctly (renders the wrapped PlaidBankAccounts)', () => {
-    const mockedProps = {
-      props: {
-        match: {
-          params: {
-            token: 'FAKEPLAIDTOKEN'
-          }
-        }
-      }
-    }
-    const wrapper = shallow(<MyPlaidAccountsContainer {...mockedProps} />)
+    setPlaidToken('FAKEPLAIDTOKEN')
+    const wrapper = shallow(<MyPlaidAccountsContainer />)
     expect(wrapper.find('PlaidBankAccounts')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Closes #82 .

Same as #84 but without using React's context API.

* Remoes Plaid token from URL.
* Stores Plaid token in localStorage.